### PR TITLE
hacktoberfest2022-labeler: Added pull_request_target

### DIFF
--- a/.github/workflows/hacktoberfest-labeler.yaml
+++ b/.github/workflows/hacktoberfest-labeler.yaml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, synchronize]
+  pull_request_target:
+    types: [opened, synchronize]
 jobs:
   triage:
     permissions:
@@ -10,9 +12,9 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - name: 'Hacktoberfest Labeler'
-      uses: actions/labeler@v4
-      with:
-        configuration-path: .github/hacktoberfest-labeler-map.yaml
-        repo-token: '${{ secrets.GITHUB_TOKEN }}'
-        sync-labels: true
+      - name: 'Hacktoberfest Labeler'
+        uses: actions/labeler@v4
+        with:
+          configuration-path: .github/hacktoberfest-labeler-map.yaml
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          sync-labels: true


### PR DESCRIPTION
pull_request_target should give the forked branch the access to the labeler.